### PR TITLE
Change example clone to be HTTPS based

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 You will need [Node.js](https://nodejs.org/en/) installed. Preferrably a version `>=4.0`. Also you will need [npm](npmjs.org) `>=3.0`. After that you should run
 
 ```bash
-$ git clone git@github.com:ipfs/station.git
+$ git clone https://github.com/ipfs/station.git
 $ cd station
 $ npm install
 $ npm start


### PR DESCRIPTION
You need to have SSH key that is assigned to GH account to be able to clone using SSH.